### PR TITLE
Ajustes para pantallas pequeñas y grandes.

### DIFF
--- a/front/src/App.css
+++ b/front/src/App.css
@@ -1,15 +1,13 @@
 /* Contenedor principal */
 .radio-app {
   min-height: 100vh;
-  color: #ffffff;
   font-family: 'Arial', sans-serif;
 }
 
 /* Contenido principal */
 .app-content {
-  padding-left: 60px;
-  padding-top: 0; /* Espacio para el RadioMenu */
-  padding-bottom: 60px; /* Espacio para el footer */
+  padding-top: 0; 
+  padding-bottom: 60px;
   transition: padding-left 0.3s ease;
   box-sizing: border-box;
   z-index: 1;
@@ -42,7 +40,7 @@
   bottom: 0;
   left: 0;
   width: 100%;
-  height: 79px; /* Altura fija para el footer */
+  height: 12.39%; /* Altura fija para el footer */
   z-index: 911; /* Alto en escritorio, pero menor que el RadioMenu */
   box-sizing: border-box;
   border-top: 1px solid;

--- a/front/src/components/Footer/Footer.module.css
+++ b/front/src/components/Footer/Footer.module.css
@@ -3,8 +3,9 @@
     bottom: 0;
     left: 0;
     width: 100%;
-    padding: 1em 2em 4em 2.7em;
-    margin: 13px 15px 18px 32px;
+    padding: 1em 2em 4em 8em;
+    margin: 13px 15px 18px 0;
+    /* margin-left: 5.8em; */
     display: flex;
     justify-content: space-between;
     align-items: flex-start;

--- a/front/src/components/RadioMenu/RadioMenu.module.css
+++ b/front/src/components/RadioMenu/RadioMenu.module.css
@@ -32,12 +32,16 @@
 
 /* Contenedor principal y botón de toggle */
 .radio-menu {
+  background-color: rgba(64, 88, 109, 0.9);
   position: fixed;
   top: 0;
   left: 0;
-  height: 100vh;
+  height: 87.6%;
   z-index: 900;
   display: flex;
+  border-right: 1px solid;
+  border-top: 1px solid;
+  justify-content: center;
 }
 
 .menu-toggle {
@@ -69,15 +73,19 @@
 
 /* Contenedor del menú */
 .menu-container {
-  background: var(--menu-background);
-  height: 151vh;
-  width: 60px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-evenly;
+  align-items: center;
+  transition: width 0.3s ease;
+  margin: 5em 0;
+}
+
+.separation {
   display: flex;
   flex-direction: column;
   align-items: center;
-  padding-top: 12em;
-  transition: width 0.3s ease;
-  border-right: 1px solid;
+  justify-content: center;
 }
 
 .menu-container.expanded {

--- a/front/src/components/RadioMenu/RadioMenu.tsx
+++ b/front/src/components/RadioMenu/RadioMenu.tsx
@@ -71,31 +71,33 @@ const RadioMenu: React.FC<RadioMenuProps> = ({ onMenuToggle }) => {
         </button>
       )}
 
-      <motion.div
-        className={`${styles['menu-container']} ${isExpanded ? styles.expanded : ''}`}
-        initial="expanded"
-        animate={isExpanded ? 'expanded' : 'collapsed'}
-        variants={menuVariants}
-        // style={{ background: 'blue' }} // Comentamos el estilo inline para probar los estilos del CSS
-      >
-        {menuItems.map((item) => (
-          <div className={styles['menu-item-wrapper']} key={item.id}>
-            <NavLink
-              to={item.path}
-              className={({ isActive }) =>
-                isActive
-                  ? `${styles['menu-item']} ${styles.active}`
-                  : styles['menu-item']
-              }
-            >
-              <span className={styles['menu-icon']}>{item.icon}</span>
-              {(isMobile || isExpanded) && (
-                <span className={styles['menu-text']}>{item.title}</span>
-              )}
-            </NavLink>
-          </div>
-        ))}
-      </motion.div>
+      <div className={styles['separation']}>
+        <motion.div
+          className={`${styles['menu-container']} ${isExpanded ? styles.expanded : ''}`}
+          initial="expanded"
+          animate={isExpanded ? 'expanded' : 'collapsed'}
+          variants={menuVariants}
+          // style={{ background: 'blue' }} // Comentamos el estilo inline para probar los estilos del CSS
+        >
+          {menuItems.map((item) => (
+            <div className={styles['menu-item-wrapper']} key={item.id}>
+              <NavLink
+                to={item.path}
+                className={({ isActive }) =>
+                  isActive
+                    ? `${styles['menu-item']} ${styles.active}`
+                    : styles['menu-item']
+                }
+              >
+                <span className={styles['menu-icon']}>{item.icon}</span>
+                {(isMobile || isExpanded) && (
+                  <span className={styles['menu-text']}>{item.title}</span>
+                )}
+              </NavLink>
+            </div>
+          ))}
+        </motion.div>
+      </div>
     </div>
   );
 };

--- a/front/src/views/Home/Home.module.css
+++ b/front/src/views/Home/Home.module.css
@@ -187,6 +187,8 @@
   text-align: center;
   margin-top: 60px; /* Espacio para el RadioMenu */
   margin-bottom: 60px; /* Espacio para el footer */
+  margin-left: 6.5em;
+  margin-right: 1em;
 }
 
 .sectionTitle {


### PR DESCRIPTION
 la navbar traspasaba la pa…ntalla, acomede los tamaños de los contenedores para que no se traspasaran, con porcentaje de la pantalla, y el home acomode los compenentes al retirar el padding en toda la app para la izquierda, para que no se corriera el video y las demás cosas,